### PR TITLE
Add KL400L10 Lightstrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Some newer Kasa devices require authentication. These are marked with [*] in the
 - **KL400L5**
   - Hardware: 1.0 (US) / Firmware: 1.0.5
   - Hardware: 1.0 (US) / Firmware: 1.0.8
+- **KL400L10**
+  - Hardware: 1.0 (US) / Firmware: 1.0.10
 - **KL420L5**
   - Hardware: 1.0 (US) / Firmware: 1.0.2
 - **KL430**

--- a/src/devices/kasaDevices.ts
+++ b/src/devices/kasaDevices.ts
@@ -161,6 +161,7 @@ export const LightBulbs = [
   'L530',
   'L630',
   'KL400L5',
+  'KL400L10',
   'KL420L5',
   'KL430',
   'L900',


### PR DESCRIPTION
Additional lightstrip model that is supported with a longer length when sold. This is already added in main kasa-python

5m ({KL400L5} 5m strip w/ 12v1A adapter) and a 10m ({KL400L10} 10m strip w/ 12v1.5A adapter) models. 