### PR TITLE
Fix child device sorting and calling

### DIFF
--- a/src/devices/homekitPowerStrip.ts
+++ b/src/devices/homekitPowerStrip.ts
@@ -28,8 +28,8 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
     );
     this.log.debug(`Initializing HomeKitDevicePowerStrip for device: ${kasaDevice.sys_info.alias}`);
     this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
-      const childIndex = this.extractChildIndex(child);
-      this.checkService(child, childIndex);
+      const index = this.extractChildIndex(child);
+      this.checkService(child, index);
     });
     this.getSysInfo = deferAndCombine(async () => {
       if (!this.deviceManager) {
@@ -64,12 +64,6 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
     });
   }
 
-  private extractChildIndex(child: ChildDevice): number {
-    const id = String(child.id ?? '');
-    const match = id.match(/(\d{1,2})$/);
-    return match ? parseInt(match[1], 10) : 0;
-  }
-
   public async initialize(): Promise<void> {
     this.log.debug(`Initializing polling for device: ${this.kasaDevice.sys_info.alias}`);
     await this.startPolling();
@@ -95,10 +89,9 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
 
   private checkService(child: ChildDevice, index: number) {
     const serviceType = this.getServiceType();
-    const subType = `child-${index + 1}`;
     const service: Service =
-      this.homebridgeAccessory.getServiceById(serviceType, subType) ??
-      this.addService(serviceType, child.alias, subType);
+      this.homebridgeAccessory.getServiceById(serviceType, `child-${index + 1}`) ??
+      this.addService(serviceType, child.alias, `child-${index + 1}`);
     const oldService: Service | undefined = this.homebridgeAccessory.getServiceById(serviceType, `outlet-${index + 1}`);
     if (oldService) {
       this.homebridgeAccessory.removeService(oldService);

--- a/src/devices/homekitPowerStrip.ts
+++ b/src/devices/homekitPowerStrip.ts
@@ -27,8 +27,9 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
       'OUTLET',
     );
     this.log.debug(`Initializing HomeKitDevicePowerStrip for device: ${kasaDevice.sys_info.alias}`);
-    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice, index: number) => {
-      this.checkService(child, index);
+    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
+      const childIndex = this.extractChildIndex(child);
+      this.checkService(child, childIndex);
     });
     this.getSysInfo = deferAndCombine(async () => {
       if (!this.deviceManager) {
@@ -63,6 +64,12 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
     });
   }
 
+  private extractChildIndex(child: ChildDevice): number {
+    const id = String(child.id ?? '');
+    const match = id.match(/(\d{1,2})$/);
+    return match ? parseInt(match[1], 10) : 0;
+  }
+
   public async initialize(): Promise<void> {
     this.log.debug(`Initializing polling for device: ${this.kasaDevice.sys_info.alias}`);
     await this.startPolling();
@@ -88,9 +95,10 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
 
   private checkService(child: ChildDevice, index: number) {
     const serviceType = this.getServiceType();
+    const subType = `child-${index + 1}`;
     const service: Service =
-      this.homebridgeAccessory.getServiceById(serviceType, `child-${index + 1}`) ??
-      this.addService(serviceType, child.alias, `child-${index + 1}`);
+      this.homebridgeAccessory.getServiceById(serviceType, subType) ??
+      this.addService(serviceType, child.alias, subType);
     const oldService: Service | undefined = this.homebridgeAccessory.getServiceById(serviceType, `outlet-${index + 1}`);
     if (oldService) {
       this.homebridgeAccessory.removeService(oldService);
@@ -203,7 +211,7 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
             if (!characteristicKey) {
               throw new Error(`Characteristic key not found for ${characteristicName}`);
             }
-            const childNumber = parseInt(child.id.slice(-1), 10);
+            const childNumber = this.extractChildIndex(child);
             await this.deviceManager.controlDevice(this.kasaDevice.sys_info.host, characteristicKey, value, childNumber);
             (child as Record<string, CharacteristicValue>)[characteristicKey] = value;
             const childIndex = this.kasaDevice.sys_info.children?.findIndex(c => c.id === child.id);
@@ -278,7 +286,7 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
         try {
           await this.getSysInfo();
           this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
-            const childNumber = parseInt(child.id.slice(-1), 10);
+            const childNumber = this.extractChildIndex(child);
             const service = this.getService(childNumber);
             if (service && this.previousKasaDevice) {
               this.updateChildState(service, child);
@@ -320,8 +328,9 @@ export default class HomeKitDevicePowerStrip extends HomeKitDevice {
   }
 
   public updateAfterPeriodicDiscovery() {
-    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice, index: number) => {
+    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
       const serviceType = this.getServiceType();
+      const index = this.extractChildIndex(child);
       const service: Service | undefined =
         this.homebridgeAccessory.getServiceById(serviceType, `child-${index + 1}`);
       if (service) {

--- a/src/devices/homekitSwitchWithChildren.ts
+++ b/src/devices/homekitSwitchWithChildren.ts
@@ -28,8 +28,8 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
     );
     this.log.debug(`Initializing HomeKitDeviceSwitchWithChildren for device: ${kasaDevice.sys_info.alias}`);
     this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
-      const childIndex = this.extractChildIndex(child);
-      this.checkService(child, childIndex);
+      const index = this.extractChildIndex(child);
+      this.checkService(child, index);
     });
     this.getSysInfo = deferAndCombine(async () => {
       if (!this.deviceManager) {
@@ -64,12 +64,6 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
     });
   }
 
-  private extractChildIndex(child: ChildDevice): number {
-    const id = String(child.id ?? '');
-    const match = id.match(/(\d{1,2})$/);
-    return match ? parseInt(match[1], 10) : 0;
-  }
-
   public async initialize(): Promise<void> {
     this.log.debug(`Initializing polling for device: ${this.kasaDevice.sys_info.alias}`);
     await this.startPolling();
@@ -95,10 +89,9 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
 
   private checkService(child: ChildDevice, index: number) {
     const serviceType = this.getServiceType(child);
-    const subType = `child-${index + 1}`;
     const service: Service =
-      this.homebridgeAccessory.getServiceById(serviceType, subType) ??
-      this.addService(serviceType, child.alias, subType);
+      this.homebridgeAccessory.getServiceById(serviceType, `child-${index + 1}`) ??
+      this.addService(serviceType, child.alias, `child-${index + 1}`);
     this.checkCharacteristics(service, child);
   }
 

--- a/src/devices/homekitSwitchWithChildren.ts
+++ b/src/devices/homekitSwitchWithChildren.ts
@@ -27,8 +27,9 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
       'SWITCH',
     );
     this.log.debug(`Initializing HomeKitDeviceSwitchWithChildren for device: ${kasaDevice.sys_info.alias}`);
-    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice, index: number) => {
-      this.checkService(child, index);
+    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
+      const childIndex = this.extractChildIndex(child);
+      this.checkService(child, childIndex);
     });
     this.getSysInfo = deferAndCombine(async () => {
       if (!this.deviceManager) {
@@ -63,6 +64,12 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
     });
   }
 
+  private extractChildIndex(child: ChildDevice): number {
+    const id = String(child.id ?? '');
+    const match = id.match(/(\d{1,2})$/);
+    return match ? parseInt(match[1], 10) : 0;
+  }
+
   public async initialize(): Promise<void> {
     this.log.debug(`Initializing polling for device: ${this.kasaDevice.sys_info.alias}`);
     await this.startPolling();
@@ -88,9 +95,10 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
 
   private checkService(child: ChildDevice, index: number) {
     const serviceType = this.getServiceType(child);
+    const subType = `child-${index + 1}`;
     const service: Service =
-      this.homebridgeAccessory.getServiceById(serviceType, `child-${index + 1}`) ??
-      this.addService(serviceType, child.alias, `child-${index + 1}`);
+      this.homebridgeAccessory.getServiceById(serviceType, subType) ??
+      this.addService(serviceType, child.alias, subType);
     this.checkCharacteristics(service, child);
   }
 
@@ -225,7 +233,7 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
             if (!characteristicKey) {
               throw new Error(`Characteristic key not found for ${characteristicName}`);
             }
-            const childNumber = parseInt(child.id.slice(-1), 10);
+            const childNumber = this.extractChildIndex(child);
             const controlValue = this.getControlValue(characteristicName, value);
             await this.deviceManager.controlDevice(this.kasaDevice.sys_info.host, characteristicKey, controlValue, childNumber);
             (child as Record<string, CharacteristicValue>)[characteristicKey] = controlValue;
@@ -302,7 +310,7 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
         try {
           await this.getSysInfo();
           this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
-            const childNumber = parseInt(child.id.slice(-1), 10);
+            const childNumber = this.extractChildIndex(child);
             const service = this.getService(child, childNumber);
             if (service && this.previousKasaDevice) {
               this.updateChildState(service, child);
@@ -372,8 +380,9 @@ export default class HomeKitDeviceSwitchWithChildren extends HomeKitDevice {
   }
 
   public updateAfterPeriodicDiscovery() {
-    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice, index: number) => {
+    this.kasaDevice.sys_info.children?.forEach((child: ChildDevice) => {
       const serviceType = this.getServiceType(child);
+      const index = this.extractChildIndex(child);
       const service: Service | undefined =
         this.homebridgeAccessory.getServiceById(serviceType, `child-${index + 1}`);
       if (service) {

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -15,7 +15,7 @@ import AccessoryInformation from '../accessoryInformation.js';
 import DeviceManager from './deviceManager.js';
 import { prefixLogger } from '../utils.js';
 import type KasaPythonPlatform from '../platform.js';
-import type { KasaDevice } from './kasaDevices.js';
+import type { KasaDevice, ChildDevice } from './kasaDevices.js';
 import type { KasaPythonAccessoryContext } from '../platform.js';
 
 export default abstract class HomeKitDevice {
@@ -105,6 +105,12 @@ export default abstract class HomeKitDevice {
 
   get firmwareRevision(): string {
     return this.kasaDevice.sys_info.sw_ver;
+  }
+
+  protected extractChildIndex(child: ChildDevice): number {
+    const id = String(child.id ?? '');
+    const match = id.match(/(\d{1,2})$/);
+    return match ? parseInt(match[1], 10) : 0;
   }
 
   abstract identify(): void;

--- a/src/python/kasaApi.py
+++ b/src/python/kasaApi.py
@@ -59,6 +59,12 @@ def log(message: str, level: str = "INFO", host: Optional[str] = None, alias: Op
     context_str = f" ({', '.join(context)})" if context else ""
     print(f"[Kasa API] {level}: {message}{context_str}", file=sys.stdout if level != "ERROR" else sys.stderr)
 
+def _extract_child_suffix_index(device_id: str) -> int:
+    base = device_id.split('_', 1)[1] if '_' in device_id else device_id
+    import re
+    m = re.search(r'(\d{1,2})$', base)
+    return int(m.group(1)) if m else 0
+
 def serialize_child(child: Device) -> Dict[str, Any]:
     log("Serializing child device", alias=child.alias)
     child_info = {
@@ -127,7 +133,8 @@ def custom_serializer(device: Device) -> Dict[str, Any]:
     fan_module = device.modules.get(Module.Fan)
     energy_module = device.modules.get(Module.Energy)
     if child_num > 0:
-        sys_info["children"] = [serialize_child(child) for child in device.children]
+        sorted_children = sorted(device.children, key=lambda c: _extract_child_suffix_index(c.device_id))
+        sys_info["children"] = [serialize_child(child) for child in sorted_children]
     else:
         sys_info.update({"state": device.features["state"].value})
         if light_module:
@@ -298,7 +305,10 @@ async def get_or_connect_device(host: str, device_config: DeviceConfig) -> Devic
         return device
     except Exception as e:
         log(f"Connect to device: {e}", level="ERROR", host=host)
-        await safe_disconnect(device)
+        try:
+            await safe_disconnect(device)
+        except Exception:
+            pass
         raise
 
 async def control_device(
@@ -333,13 +343,13 @@ async def perform_device_action(
         fan = target.modules.get(Module.Fan)
         if feature == "state":
             await getattr(target, action)()
-        elif feature == "brightness" and light.has_feature("brightness"):
+        elif feature == "brightness" and light and light.has_feature("brightness"):
             await handle_brightness(target, action, value)
-        elif feature == "color_temp" and light.has_feature("color_temp"):
+        elif feature == "color_temp" and light and light.has_feature("color_temp"):
             await handle_color_temp(target, action, value)
-        elif feature == "fan_speed_level" and fan:
+        elif feature == "fan_speed_level" and fan and fan.has_feature("fan_speed_level"):
             await handle_fan_speed_level(target, action, value)
-        elif feature == 'hsv' and light.has_feature("hsv"):
+        elif feature == 'hsv' and light and light.has_feature("hsv"):
             await handle_hsv(target, action, feature, value)
         else:
             raise ValueError("Invalid feature or action")

--- a/src/python/kasaApi.py
+++ b/src/python/kasaApi.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import re
 import sys
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -61,7 +62,6 @@ def log(message: str, level: str = "INFO", host: Optional[str] = None, alias: Op
 
 def _extract_child_suffix_index(device_id: str) -> int:
     base = device_id.split('_', 1)[1] if '_' in device_id else device_id
-    import re
     m = re.search(r'(\d{1,2})$', base)
     return int(m.group(1)) if m else 0
 


### PR DESCRIPTION
Fixed child device sorting during device discovery and now uses extracted child index from child device id instead of stationary index numbers.