### PR TITLE
Adding Tapo P105 as plug type

### DIFF
--- a/src/devices/deviceTypes.ts
+++ b/src/devices/deviceTypes.ts
@@ -105,7 +105,7 @@ export interface ConfigDevice {
 
 export const Plugs = [
   'EP10', 'EP25', 'HS100', 'HS103', 'HS105', 'HS110', 'KP100', 'KP105', 'KP115', 'KP125', 'KP125M',
-  'KP401', 'P100', 'P110', 'P110M', 'P115', 'P125M', 'P135', 'TP15',
+  'KP401', 'P100', 'P105', 'P110', 'P110M', 'P115', 'P125M', 'P135', 'TP15',
 ];
 export const PowerStrips = [
   'EP40', 'EP40M', 'HS107', 'HS300', 'KP200', 'KP303', 'KP400', 'P210M', 'P300', 'P304M', 'P306', 'P400M', 'TP25',


### PR DESCRIPTION
Tested working with my P105 plugs

# Pull Request

<!--
Thank you for your contribution!

Default base branch
- Pull requests should target the 'beta' branch by default.
- If you chose a different base, the workflow will retarget this PR to 'beta'.

Please complete the sections below to help with review and release notes.
-->

## Summary
<!-- Short description of the change. What does this PR do? -->

Adding Tapo P105 as plug type, tested working with my Tapo P105 plugs

## Type (choose at least one classification)
<!-- At least one of these is required by validation -->
- [ ] fix (bug fix)
- [ ] bug
- [x] enhancement / feature
- [ ] docs
- [ ] dependency
- [ ] breaking-change
- [ ] internal / workflow

## Details
<!-- Why is this needed? What problem does it solve? Include links, context, etc. -->

## Testing
<!-- How did you test it? Steps, cases, environments. -->
- [ ] Build OK (`npm run build`)
- [ ] Lint clean
- [ ] Node import OK
- [ ] Python import OK
- [ ] Device(s) tested: <!-- list -->
- [ ] No unrelated changes

## Screenshots / Logs (optional)

## Breaking Change Explanation (REQUIRED if breaking-change label)
Markers exactly:

BREAKING_CHANGE_EXPLANATION_START
<explanation of what breaks, why unavoidable, migration steps>
BREAKING_CHANGE_EXPLANATION_END

## Checklist
- [ ] Base branch is `beta`
- [ ] Classification labels applied (see “Type” above)
- [ ] Changelog impact understood
- [ ] Docs updated where appropriate
- [ ] Linked issues (if any): [#ISSUE_NUMBER]