### PR TITLE
Fix energy monitor logging setting

### DIFF
--- a/src/devices/baseDevice.ts
+++ b/src/devices/baseDevice.ts
@@ -438,7 +438,7 @@ export default abstract class HomeKitDevice {
     const isEnergyCharacteristic = this.isEnergyMonitoringCharacteristic(characteristic);
     if (force || needsInit || previousValue !== nextValue) {
       if (label) {
-        if (!isEnergyCharacteristic || this.platform.config.advancedOptions.logEnergyMonitoring) {
+        if (!isEnergyCharacteristic || (isEnergyCharacteristic && this.platform.config.advancedOptions.logEnergyMonitoring)) {
           this.log.debug(`[${alias}] Updating ${label}: ${previousValue} → ${nextValue}`);
         }
       }
@@ -459,7 +459,7 @@ export default abstract class HomeKitDevice {
     value: Nullable<CharacteristicValue> | Error | HapStatusError,
   ): void {
     const isEnergyCharacteristic = this.isEnergyMonitoringCharacteristic(characteristic);
-    if (!isEnergyCharacteristic || this.platform.config.advancedOptions.logEnergyMonitoring) {
+    if (!isEnergyCharacteristic || (isEnergyCharacteristic && this.platform.config.advancedOptions.logEnergyMonitoring)) {
       this.log.info(`Updating ${this.platform.lsc(service, characteristic)} on ${deviceAlias} to ${value}`);
     }
     characteristic.updateValue(value);

--- a/src/devices/baseDevice.ts
+++ b/src/devices/baseDevice.ts
@@ -435,9 +435,12 @@ export default abstract class HomeKitDevice {
     force = false,
   ): void {
     const needsInit = characteristic.value === undefined || characteristic.value === null;
+    const isEnergyCharacteristic = this.isEnergyMonitoringCharacteristic(characteristic);
     if (force || needsInit || previousValue !== nextValue) {
       if (label) {
-        this.log.debug(`[${alias}] Updating ${label}: ${previousValue} → ${nextValue}`);
+        if (!isEnergyCharacteristic || this.platform.config.advancedOptions.logEnergyMonitoring) {
+          this.log.debug(`[${alias}] Updating ${label}: ${previousValue} → ${nextValue}`);
+        }
       }
       this.updateValue(service, characteristic, alias, nextValue as unknown as Nullable<CharacteristicValue>);
     }
@@ -455,8 +458,24 @@ export default abstract class HomeKitDevice {
     deviceAlias: string,
     value: Nullable<CharacteristicValue> | Error | HapStatusError,
   ): void {
-    this.log.info(`Updating ${this.platform.lsc(service, characteristic)} on ${deviceAlias} to ${value}`);
+    const isEnergyCharacteristic = this.isEnergyMonitoringCharacteristic(characteristic);
+    if (!isEnergyCharacteristic || this.platform.config.advancedOptions.logEnergyMonitoring) {
+      this.log.info(`Updating ${this.platform.lsc(service, characteristic)} on ${deviceAlias} to ${value}`);
+    }
     characteristic.updateValue(value);
+  }
+
+  private isEnergyMonitoringCharacteristic(characteristic: Characteristic): boolean {
+    if (!this.platform.energyCharacteristics) {
+      return false;
+    }
+    const uuid = characteristic.UUID;
+    return (
+      uuid === this.platform.energyCharacteristics.Volts.UUID ||
+      uuid === this.platform.energyCharacteristics.Amperes.UUID ||
+      uuid === this.platform.energyCharacteristics.Watts.UUID ||
+      uuid === this.platform.energyCharacteristics.KiloWattHours.UUID
+    );
   }
 
   public abstract initialize(): Promise<void>;


### PR DESCRIPTION
# Pull Request

## Summary
<!-- Short description of the change. What does this PR do? -->
Fixes https://github.com/ZeliardM/homebridge-kasa-python/issues/233

## Type (choose at least one classification)
<!-- At least one of these is required by validation -->
- [x] fix (bug fix)
- [ ] bug
- [ ] enhancement / feature
- [ ] docs
- [ ] dependency
- [ ] breaking-change
- [ ] internal / workflow

## Details
<!-- Why is this needed? What problem does it solve? Include links, context, etc. -->
Honour the existing setting

## Testing
<!-- How did you test it? Steps, cases, environments. -->
- [x] Build OK (`npm run build`)
- [x] Lint clean
- [x] Node import OK
- [x] Python import OK
- [x] Device(s) tested: KP125M
- [x] No unrelated changes

## Screenshots / Logs (optional)

## Breaking Change Explanation (REQUIRED if breaking-change label)
Markers exactly:

BREAKING_CHANGE_EXPLANATION_START
<explanation of what breaks, why unavoidable, migration steps>
BREAKING_CHANGE_EXPLANATION_END

## Checklist
- [x] Base branch is `beta`
- [x] Classification labels applied (see “Type” above)
- [x] Changelog impact understood
- [x] Docs updated where appropriate
- [x] Linked issues (if any): #233 