### PR TITLE
fix: avoid sys_info crashes during network interruptions

### DIFF
--- a/src/devices/deviceManager.ts
+++ b/src/devices/deviceManager.ts
@@ -95,15 +95,16 @@ export default class DeviceManager {
   async getSysInfo(host: string): Promise<SysInfo | undefined> {
     try {
       const response = await axios.post(`${this.apiUrl}/getSysInfo`, { host });
-      const sysInfo: SysInfo = response.data.sys_info;
+      const sysInfo: SysInfo | undefined = response.data?.sys_info;
       if (!sysInfo) {
+        this.log.debug(`[getSysInfo] No sys_info payload returned for host ${host}`);
         return undefined;
       }
       this.updateDeviceAlias(sysInfo);
       return sysInfo;
     } catch (error) {
       this.handleAxiosError(error, 'getSysInfo');
-      throw error;
+      return undefined;
     }
   }
 


### PR DESCRIPTION
Fixes #44

During brief network outages, getSysInfo could receive a response without data.sys_info or throw and rethrow, which cascaded into noisy runtime errors in the polling path.

This adds a safe payload check and returns undefined after logging the axios error, so callers can mark the device offline cleanly instead of crashing on undefined properties.

Greetings, saschabuehrle