### PR TITLE
EVE power on/off and consumption history views for plug.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,9 @@
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/node": "^25.5.0",
         "eslint": "^10.1.0",
+        "fakegato-history": "^0.6.7",
         "homebridge": "^2.0.0-beta.79",
+        "homebridge-lib": "^7.3.1",
         "nodemon": "^3.1.14",
         "rimraf": "^6.1.3",
         "ts-node": "^10.9.2",
@@ -300,6 +302,13 @@
       "engines": {
         "node": "^22 || ^24"
       }
+    },
+    "node_modules/@homebridge/plugin-ui-utils": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@homebridge/plugin-ui-utils/-/plugin-ui-utils-2.2.3.tgz",
+      "integrity": "sha512-kKieIJM1Wyv4TzzE/amUKwR4UnlDH6Th52axG2e5ncH4iA5w+HNfPDAqX1nitdhyHtHqNlTK6DdeE71QzO5LNQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -918,6 +927,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -987,6 +1006,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1036,6 +1086,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1056,6 +1113,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1064,6 +1138,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -1140,6 +1227,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -1219,6 +1316,16 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1550,6 +1657,45 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fakegato-history": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/fakegato-history/-/fakegato-history-0.6.7.tgz",
+      "integrity": "sha512-gB5W5M7xI++vDUo7SEBVw/UP0+YULFSwalQw8lO33qY7cZVPUx3s8OTjA2plmzWU57D0bq5Tb3KtpKQ4Z7TZ0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "googleapis": ">39.1.0"
+      },
+      "engines": {
+        "homebridge": ">=0.4.0",
+        "node": ">=4.3.2"
+      }
+    },
+    "node_modules/fakegato-history/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/fakegato-history/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1579,6 +1725,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -1681,6 +1851,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
@@ -1735,6 +1918,36 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1857,6 +2070,65 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "171.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
+      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1925,6 +2197,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hb-lib-tools": {
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/hb-lib-tools/-/hb-lib-tools-2.2.18.tgz",
+      "integrity": "sha512-FtHfodJDz9yrl38NepWfPxO09j/fhvzBzHDECCxoIM+HMiy5JlNkFc8M6W5pQ476PDirneOJXn58MpBLWecMLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bonjour-hap": "^3.10.0",
+        "chalk": "^5.6.2",
+        "semver": "^7.7.4"
+      },
+      "bin": {
+        "hap": "cli/hap.js",
+        "json": "cli/json.js",
+        "sysinfo": "cli/sysinfo.js",
+        "upnp": "cli/upnp.js"
+      },
+      "engines": {
+        "node": "24.14.0||^24||^22||^20"
+      }
+    },
     "node_modules/hexy": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
@@ -1961,17 +2254,39 @@
         "node": "^22 || ^24"
       }
     },
-    "node_modules/homebridge/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+    "node_modules/homebridge-lib": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/homebridge-lib/-/homebridge-lib-7.3.2.tgz",
+      "integrity": "sha512-t8X/LhkiE+B+h2PWJAW53VcJ3jqUP+/KmbxxNJ/PdMKKcMWJwWWXpoZjdGYMV2YT947L5E6fDJa04Q86LZLQsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@homebridge/plugin-ui-utils": "~2.2.1",
+        "hb-lib-tools": "~2.2.18"
+      },
+      "bin": {
+        "hap": "cli/hap.js",
+        "json": "cli/json.js",
+        "sysinfo": "cli/sysinfo.js",
+        "upnp": "cli/upnp.js"
+      },
+      "engines": {
+        "homebridge": "^1.11.2||^2.0.0-beta",
+        "node": "24.14.0||^24||^22||^20"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
       },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -2084,6 +2399,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2116,6 +2441,29 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -2287,6 +2635,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-persist": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-4.0.4.tgz",
@@ -2389,6 +2777,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/optionator": {
@@ -2566,6 +2967,22 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2674,6 +3091,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/simple-update-notifier": {
@@ -2988,12 +3481,29 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "dev": true,
+      "license": "BSD"
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "rimraf": "^6.1.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.57.1"
+    "typescript-eslint": "^8.57.1",
+    "fakegato-history": "^0.6.7",
+    "homebridge-lib": "^7.3.1"
   },
   "homepage": "https://github.com/ZeliardM/homebridge-kasa-python#readme",
   "funding": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,7 @@ export interface KasaPythonConfigInput {
   waitTimeUpdate?: number;
   pythonPath?: string;
   advancedPythonLogging?: boolean;
+  enableEveHistoryView?: boolean;
 }
 
 export type KasaPythonConfig = {
@@ -62,6 +63,7 @@ export type KasaPythonConfig = {
     enableEnergyMonitoring: boolean;
     powerThreshold: number;
     logEnergyMonitoring: boolean;
+    enableEveHistoryView: boolean;
   };
   homekitOptions: {
     hideHomeKitMatter: boolean;
@@ -91,6 +93,7 @@ export const defaultConfig: KasaPythonConfig = {
     enableEnergyMonitoring: false,
     powerThreshold: 2,
     logEnergyMonitoring: false,
+    enableEveHistoryView: false,
   },
   homekitOptions: {
     hideHomeKitMatter: true,
@@ -187,6 +190,7 @@ function validateConfig(config: Record<string, unknown>): string[] {
   validateType(config, 'pollingInterval', 'number', errors);
   validateType(config, 'discoveryPollingInterval', 'number', errors);
   validateType(config, 'offlineInterval', 'number', errors);
+  validateType(config, 'enableEveHistoryView', 'boolean', errors);
 
   if (config.additionalBroadcasts !== undefined && !Array.isArray(config.additionalBroadcasts)) {
     errors.push('`additionalBroadcasts` should be an array of strings.');
@@ -263,6 +267,7 @@ export function parseConfig(config: Record<string, unknown>): KasaPythonConfig {
       enableEnergyMonitoring: parsedConfig.enableEnergyMonitoring ?? defaultConfig.energyOptions.enableEnergyMonitoring,
       powerThreshold: parsedConfig.powerThreshold ?? defaultConfig.energyOptions.powerThreshold,
       logEnergyMonitoring: parsedConfig.logEnergyMonitoring ?? defaultConfig.energyOptions.logEnergyMonitoring,
+      enableEveHistoryView: parsedConfig.enableEveHistoryView ?? defaultConfig.energyOptions.enableEveHistoryView,
     },
     homekitOptions: {
       hideHomeKitMatter: parsedConfig.hideHomeKitMatter ?? defaultConfig.homekitOptions.hideHomeKitMatter,

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,2 @@
+declare module 'homebridge-lib/EveHomeKitTypes';
+declare module 'fakegato-history';

--- a/src/devices/baseDevice.ts
+++ b/src/devices/baseDevice.ts
@@ -303,6 +303,7 @@ export default abstract class HomeKitDevice {
     onGet: () => Promise<CharacteristicValue>,
     onSet?: (value: CharacteristicValue) => Promise<void>,
   ): void {
+    service.addOptionalCharacteristic(type);
     const characteristic = service.getCharacteristic(type) ?? service.addCharacteristic(type);
     characteristic.onGet(onGet);
     if (onSet) {

--- a/src/devices/homekitPlug.ts
+++ b/src/devices/homekitPlug.ts
@@ -10,12 +10,165 @@ import type KasaPythonPlatform from '../platform.js';
 import type { CharacteristicDescriptor, Plug } from './deviceTypes.js';
 
 export default class HomeKitDevicePlug extends HomeKitDevice {
+  /* eslint @typescript-eslint/no-explicit-any: 0 */
+  private historyService: any;
+
   constructor(
     platform: KasaPythonPlatform,
     public kasaDevice: Plug,
   ) {
     super(platform, kasaDevice, Categories.OUTLET, 'OUTLET');
     this.setupPrimaryService();
+    this.setupEveHistoryService();
+  }
+
+  private setupEveHistoryService () : void {
+    const { Characteristic, Service, api, eve } = this.platform;
+    const accessory = this.homebridgeAccessory;
+    const outlet = accessory.getService(Service.Outlet);
+
+    if (!this.platform.config.energyOptions.enableEveHistoryView) {
+      // cached accessory to be restored if disabled.
+      [
+        eve.Services.Consumption,
+      ].forEach((x) => {
+        const s = accessory.getService(x);
+        if (s) {
+          accessory.removeService(s);
+        }
+      });
+      [
+        eve.Characteristics.LastActivation,
+        Characteristic.LockPhysicalControls,
+        eve.Characteristics.TotalConsumption,
+        eve.Characteristics.ResetTotal,
+      ].forEach((x) => {
+        if (outlet?.testCharacteristic(x)) {
+          const c = outlet?.getCharacteristic(x);
+          outlet.removeCharacteristic(c);
+        }
+      });
+      delete(accessory.context.lastActivation);
+      delete(accessory.context.totalConsumption);
+
+      return;
+    }
+
+    // open event stream
+    this.historyService = new this.platform.HistoryService(
+      'custom', accessory, { storage: 'fs' },
+    );
+
+    //LastActivation characteristic
+    const lastActivation = eve.Characteristics.LastActivation;
+    outlet?.addOptionalCharacteristic(lastActivation);
+    outlet?.getCharacteristic(lastActivation).onGet(() => {
+      const initialTime = this.historyService?.getInitialTime();
+      const lastTime = accessory.context.lastActivation && initialTime
+        ? Math.max(0, accessory.context.lastActivation - initialTime)
+        : 0;
+      return lastTime;
+    });
+
+    // logging on/off status
+    const On = outlet?.getCharacteristic(Characteristic.On);
+    On?.on('change', async (event) => {
+      if (event.newValue !== event.oldValue) {
+        const accessory = this.homebridgeAccessory;
+        accessory.context.lastActivation = Math.round(new Date().valueOf() / 1000);
+        this.historyService?.addEntry({
+          time: accessory.context.lastActivation,
+          status: event.newValue ? 1 : 0,
+        });
+      }
+    });
+    this.historyService?.addEntry({
+      time: Math.round(new Date().valueOf() / 1000),
+      status: On?.value ? 1 : 0,
+    });
+
+    // LockPhysicalControls characteristic
+    const lockControl = Characteristic.LockPhysicalControls;
+    outlet?.addOptionalCharacteristic(lockControl);
+    outlet?.getCharacteristic(lockControl).onGet(() =>
+      Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED,
+    );
+
+    if (this.platform.config.energyOptions.enableEnergyMonitoring &&
+	this.platform.energyCharacteristics &&
+	(this.kasaDevice.feature_info.energy || this.kasaDevice.sys_info.energy)) {
+      // dummy consumption service to be removed if previously configured
+      [
+        eve.Services.Consumption,
+      ].forEach((x) => {
+        const s = accessory.getService(x);
+        if (s) {
+          accessory.removeService(s);
+        }
+      });
+
+      // totalConsumption characteristic
+      accessory.context.totalConsumption ??= 0;
+      const totalConsumption = eve.Characteristics.TotalConsumption;
+      outlet?.addOptionalCharacteristic(totalConsumption);
+      outlet?.getCharacteristic(totalConsumption).onGet(() => {
+        const accessory = this.homebridgeAccessory;
+        const totalConsumption = accessory.context.totalConsumption ?? 0;
+        return totalConsumption / 1000;
+      });
+
+      // resetTotal characteristic
+      const resetTotal = eve.Characteristics.ResetTotal;
+      outlet?.addOptionalCharacteristic(resetTotal);
+      outlet?.getCharacteristic(resetTotal)
+        .onSet((_reset) => {
+          const accessory = this.homebridgeAccessory;
+          accessory.context.totalConsumption = 0;
+        })
+        // .onGet(() => {
+        //   return this.historyService.getInitialTime() - Math.round(Date.parse('01 Jan 2001 00:00:00 GMT')/1000);
+        // })
+      ;
+
+      // logging power
+      this.updateEmitter.on('updateComplete', () => {
+        const accessory = this.homebridgeAccessory;
+        const power = this.kasaDevice?.sys_info?.energy?.power;
+        const interval = this.platform.config.discoveryOptions.pollingInterval / 1000;
+        const watts = power ? power / 3600 * interval: 0;
+        accessory.context.totalConsumption! += watts;
+        this.historyService?.addEntry({
+          time: Math.round(new Date().valueOf() / 1000),
+          power: watts,
+        });
+      });
+    } else {
+      // totalConsumption characteristic to be removed if previously configured
+      [
+        eve.Characteristics.TotalConsumption,
+        eve.Characteristics.ResetTotal,
+      ].forEach((x) => {
+        if (outlet?.testCharacteristic(x)) {
+          const c = outlet?.getCharacteristic(x);
+          outlet.removeCharacteristic(c);
+        }
+      });
+      delete(accessory.context.totalConsumption);
+
+      // dummy consumption service to enable switching history
+      const dummy =
+        accessory.getService(eve.Services.Consumption) ??
+        accessory.addService(eve.Services.Consumption, `${this.name} Consumption`);
+      dummy?.setHiddenService(true);
+      dummy?.addOptionalCharacteristic(eve.Characteristics.TotalConsumption);
+      dummy?.getCharacteristic(eve.Characteristics.TotalConsumption).setProps({
+        perms: [
+          api.hap.Perms.PAIRED_READ,
+          api.hap.Perms.NOTIFY,
+          api.hap.Perms.HIDDEN,
+        ],
+      });
+    }
   }
 
   public async initialize(): Promise<void> {

--- a/src/devices/homekitPlug.ts
+++ b/src/devices/homekitPlug.ts
@@ -12,6 +12,7 @@ import type { CharacteristicDescriptor, Plug } from './deviceTypes.js';
 export default class HomeKitDevicePlug extends HomeKitDevice {
   /* eslint @typescript-eslint/no-explicit-any: 0 */
   private historyService: any;
+  private eveKeepAliveInterval?: NodeJS.Timeout = undefined;
 
   constructor(
     platform: KasaPythonPlatform,
@@ -71,8 +72,8 @@ export default class HomeKitDevicePlug extends HomeKitDevice {
     });
 
     // logging on/off status
-    const On = outlet?.getCharacteristic(Characteristic.On);
-    On?.on('change', async (event) => {
+    const on = outlet?.getCharacteristic(Characteristic.On);
+    on?.on('change', async (event) => {
       if (event.newValue !== event.oldValue) {
         const accessory = this.homebridgeAccessory;
         accessory.context.lastActivation = Math.round(new Date().valueOf() / 1000);
@@ -84,7 +85,7 @@ export default class HomeKitDevicePlug extends HomeKitDevice {
     });
     this.historyService?.addEntry({
       time: Math.round(new Date().valueOf() / 1000),
-      status: On?.value ? 1 : 0,
+      status: on?.value ? 1 : 0,
     });
 
     // LockPhysicalControls characteristic
@@ -167,6 +168,23 @@ export default class HomeKitDevicePlug extends HomeKitDevice {
           api.hap.Perms.NOTIFY,
           api.hap.Perms.HIDDEN,
         ],
+      });
+
+      // keep alive every 10 minutes just in case.
+      this.eveKeepAliveInterval = setInterval(() => {
+        const accessory = this.homebridgeAccessory;
+        const outlet = accessory.getService(Service.Outlet);
+        const on = outlet?.getCharacteristic(Characteristic.On);
+        this.historyService?.addEntry({
+          time: Math.round(new Date().valueOf() / 1000),
+          status: on?.value ? 1 : 0,
+        });
+      }, 10 * 60 * 1000);
+      api.on('shutdown', () => {
+        if (this.eveKeepAliveInterval) {
+          clearInterval(this.eveKeepAliveInterval);
+	  this.eveKeepAliveInterval = undefined;
+        }
       });
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -33,6 +33,8 @@ import {
   waitForServer,
 } from './utils.js';
 import { createEnergyCharacteristics } from './devices/energyCharacteristics.js';
+import { EveHomeKitTypes } from 'homebridge-lib/EveHomeKitTypes';
+import Fakegato from 'fakegato-history';
 import type { KasaPythonConfig } from './config.js';
 import type { KasaDevice } from './devices/deviceTypes.js';
 import type { EnergyCharacteristics } from './devices/energyCharacteristics.js';
@@ -41,6 +43,8 @@ export type KasaPythonAccessoryContext = {
   deviceId?: string;
   lastSeen?: Date;
   offline?: boolean;
+  lastActivation?: number;
+  totalConsumption?: number;
 };
 
 let packageConfig: { name: string; version: string; engines: { node: string } };
@@ -61,6 +65,8 @@ export default class KasaPythonPlatform implements DynamicPlatformPlugin {
   public port: number = 0;
   public taskQueue: TaskQueue;
   public venvPythonExecutable: string = '';
+  public HistoryService;
+  public eve;
   private readonly homekitDevicesById: Map<string, HomeKitDevice> = new Map();
   private deviceDiscoveredHandler?: (device: KasaDevice) => Promise<void>;
   private discoveryInterval?: NodeJS.Timeout;
@@ -78,6 +84,8 @@ export default class KasaPythonPlatform implements DynamicPlatformPlugin {
       : undefined;
     this.periodicDeviceDiscoveryEmitter = new EventEmitter();
     this.taskQueue = new TaskQueue(this.log, () => this.isShuttingDown);
+    this.HistoryService = Fakegato(this.api);
+    this.eve = new EveHomeKitTypes(this.api);
 
     this.periodicDeviceDiscoveryEmitter.setMaxListeners(255);
     this.setupDeviceEventEmitter('firstDiscovery');


### PR DESCRIPTION
# Pull Request

<!--
Thank you for your contribution!

Default base branch
- Pull requests should target the 'beta' branch by default.
- If you chose a different base, the workflow will retarget this PR to 'beta'.

Please complete the sections below to help with review and release notes.
-->
EVE history views of on/off and power consumption for plug devices.

## Summary
<!-- Short description of the change. What does this PR do? -->

This PR implements the EVE history views using [fakegato-history](https://github.com/simont77/fakegato-history) and [homebridge-lib](https://github.com/ebaauw/homebridge-lib).


## Type (choose at least one classification)
<!-- At least one of these is required by validation -->
- [ ] fix (bug fix)
- [ ] bug
- [x] enhancement / feature
- [ ] docs
- [ ] dependency
- [ ] breaking-change
- [ ] internal / workflow

## Details
<!-- Why is this needed? What problem does it solve? Include links, context, etc. -->

New boolean config option "enableEveHistoryView" is added to enable/disable the history views. The history data are stored in  local storage under user storagePath and the file name is "${hostname}_ ${devicename}_persist.json".

The power consumption are calculated from device power and polling interval, and are averaged every 10 minutes.

Don't enable the option for more than one instance of an identical device. EVE identifies the history data based on the serial number of the instances. If multiple instances having same serial number exist, that will cause wrong results. 

For the devices without power reporting functions (e.g. HS105), Total cost view with blank data will be presented. Disable it from edit control.

Note that characteristic/service definitions for EVE from homebridge-lib duplicates current own implementations. This is not a problem, but may want to unify to either.

Recently I purchased a device with power monitoring function for the first time. I implemented this feature just for fun and sharing according to the free software philosophy. I don't mind if rejected due to a conflict in policy of this repository.

## Testing
<!-- How did you test it? Steps, cases, environments. -->
- [x] Build OK (`npm run build`)
- [x] Lint clean
- [x] Node import OK
- [ ] Python import OK
- [x] Device(s) tested: <!-- list --> Kasa HS105, Tapo P110
- [x] No unrelated changes

## Screenshots / Logs (optional)
Kasa-HS105 without power monitoring function
<img width="2044" height="1399" alt="Kasa HS105" src="https://github.com/user-attachments/assets/73b19a82-a104-4b8e-8f03-605efe147793" />
Tapo-P110 with power monitoring function
<img width="2048" height="1399" alt="Tapo P110" src="https://github.com/user-attachments/assets/e5940dff-2de1-4e41-87a3-d084cc0ab36b" />

## Breaking Change Explanation (REQUIRED if breaking-change label)

## Checklist
- [x] Base branch is `beta`
- [x] Classification labels applied (see “Type” above)
- [ ] Changelog impact understood
- [ ] Docs updated where appropriate
- [ ] Linked issues (if any): #123