### PR TITLE
Bind Kasa helper API to loopback only

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "npm ci && rimraf -I ./dist && tsc && node copyPythonFiles.js",
     "lint": "eslint src/**/*.ts --max-warnings=0",
     "prepublishOnly": "npm run lint && npm run build",
-    "test": "echo \"No test specified\" && exit 0",
+    "test": "node --test",
     "watch": "npm run build && npm link && nodemon"
   },
   "keywords": [

--- a/src/python/startKasaApi.py
+++ b/src/python/startKasaApi.py
@@ -13,7 +13,9 @@ def start_api(port: int, hideHomeKitMatter: bool):
 
         uvicorn.run(
             "kasaApi:app",
-            host="0.0.0.0",
+            # The Node.js plugin is the only intended caller. Keep the helper
+            # off the LAN; Homebridge talks to it through 127.0.0.1.
+            host="127.0.0.1",
             port=port,
             loop="asyncio",
             workers=1,

--- a/test/startKasaApi.test.mjs
+++ b/test/startKasaApi.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+const startApi = await readFile(new URL("../src/python/startKasaApi.py", import.meta.url), "utf8");
+
+test("the Kasa helper binds to loopback only", () => {
+  assert.match(startApi, /host="127\.0\.0\.1"/);
+  assert.doesNotMatch(startApi, /host="0\.0\.0\.0"/);
+});


### PR DESCRIPTION
## Summary

The Python Kasa helper is used only by the Node.js Homebridge plugin through `127.0.0.1`, but it currently binds uvicorn to `0.0.0.0`. This exposes an unauthenticated internal control API on the host network whenever the dynamically selected port is reachable.

This change binds the helper to `127.0.0.1` so the existing local caller contract is preserved while LAN access is prevented.

## Changes

- Bind `startKasaApi.py` to `127.0.0.1` instead of all interfaces.
- Add a regression test that rejects wildcard binding.
- Replace the no-op test script with `node --test`.

## Verification

- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`

The change addresses a comment in a security scan on my deployment